### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/grok_copilot_image_launcher.py
+++ b/grok_copilot_image_launcher.py
@@ -99,7 +99,7 @@ def extract_biconomy_info():
                     BICONOMY_API_KEY = part.split("=")[1]
                 elif part.startswith("FORWARDER_ADDRESS="):
                     FORWARDER_ADDRESS = part.split("=")[1]
-            print(f"🌠 Extracted Biconomy info: API={BICONOMY_API_KEY[:8]}... ADDR={FORWARDER_ADDRESS[:10]}...")
+            print("🌠 Extracted Biconomy info from image metadata.")
         else:
             print("🛸 No Biconomy info in image—using env vars.")
 


### PR DESCRIPTION
Potential fix for [https://github.com/WhiteAiBlock/Dream-mind-lucid/security/code-scanning/1](https://github.com/WhiteAiBlock/Dream-mind-lucid/security/code-scanning/1)

To fix the flagged issue, the code must avoid logging sensitive credential material (such as API keys and addresses) in any form, even truncated. In particular, the print statement at line 102 must be changed so that it does not output the actual value (or any part) of `BICONOMY_API_KEY` or `FORWARDER_ADDRESS`.  
The best fix is to replace the statement with a message indicating success or presence of the information, without exposing its actual value or structure. For example, instead of printing the values, print "Extracted Biconomy info from image metadata." This confirms to the operator that extraction was successful while maintaining secrecy.  
Only the print statement at line 102 requires change. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
